### PR TITLE
Create CODEOWNERS and set the default owners for everything

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,9 @@
+# A file that specify "who owns the file?"
+# Each line is a file pattern followed by one or more owners.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @andinaufal120


### PR DESCRIPTION
# About CODEOWNERS file
`CODEOWNERS` file specifies the owner(s) of specific files in repo. The default owner is @andinaufal120 for everything which the owner has not been specified explicitly in the `CODEOWNERS` file.

# CODEOWNERS syntax
`CODEOWNERS` syntax:
````
file-pattern @file-owner-username
````

Or if you want to use email instead:
````
file-pattern owner@example.com
````

## Examples
LICENSE file is owned by @andinaufal120:
````
LICENSE @andinaufal120
````

Any files with `.txt` extension:
````
*.txt @andinaufal120 @Sulthan-eng
````

Everything inside a directory (does not apply recursively:
````
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/* @Sulthan-eng
````

For more info of `CODEOWNERS` file, see [About code owners - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).