### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      repository-projects: write
 
     steps:
     - uses: actions/checkout@v4        


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/labeler.yml` file. The change adds `repository-projects: write` to the permissions section for the workflow's jobs.