### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      repository-projects: write
+      issues: write
 
     steps:
     - uses: actions/checkout@v4        


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/labeler.yml` file. The change modifies the permissions configuration for the GitHub Actions workflow by replacing `repository-projects: write` with `issues: write`.