### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
 


### PR DESCRIPTION
This pull request modifies the permissions in the GitHub Actions workflow file `.github/workflows/labeler.yml` to allow writing to repository contents.

Permissions update:

* [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bL16-R16): Changed `contents` permission from `read` to `write` to enable the workflow to modify repository contents.