### PR TITLE
feat: anticipate typo for branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "features/**", "fix/**", "hotfix/**", "docs/**" ]
+    branches: [ "features/**", "feature/**", "fix/**", "hotfix/**", "docs/**", "doc/**" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
People keep confused whether to put 's' or no in the branch name.