### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/erupsi/erupsi-erp/security/code-scanning/1](https://github.com/erupsi/erupsi-erp/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. For a typical Node.js CI workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (top-level, after `name:` and before `on:`) to apply to all jobs, or at the job level if different jobs require different permissions. In this case, adding the following block after the `name:` line is the best approach:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed. Only the `.github/workflows/ci.yml` file needs to be edited, and the change should be made after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
