### PR TITLE
change: change certs dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10446,6 +10446,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10825,6 +10834,14 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/promise-inflight": {
@@ -13574,11 +13591,24 @@
       "resolved": "src/backend/user-service",
       "link": true
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -14247,6 +14277,7 @@
         "https": "^1.0.0",
         "jest-fetch-mock": "^3.0.3",
         "jsonwebtoken": "^9.0.2",
+        "path": "^0.12.7",
         "pg": "^8.16.3",
         "uuid": "^11.1.0",
         "validator": "^13.15.15"

--- a/src/backend/auth-service/package.json
+++ b/src/backend/auth-service/package.json
@@ -40,6 +40,7 @@
     "https": "^1.0.0",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.2",
+    "path": "^0.12.7",
     "pg": "^8.16.3",
     "uuid": "^11.1.0",
     "validator": "^13.15.15"

--- a/src/backend/auth-service/src/app.js
+++ b/src/backend/auth-service/src/app.js
@@ -83,8 +83,8 @@ app.use(limiter);
 
 app.use(session(sessionOption)); // TOBE DETERMINED
 const fsOptions = {
-    key: fs.readFileSync("/home/perhanjay/.keys/localhost+1-key.pem"), // Path ke file kunci // DELETE LATER
-    cert: fs.readFileSync("/home/perhanjay/.keys/localhost+1.pem"), // DELETE LATER
+    key: fs.readFileSync("../../../../certs/localhost+1-key.pem"),
+    cert: fs.readFileSync("../../../../certs/localhost+1.pem"),
 };
 
 // Middleware setup

--- a/src/backend/auth-service/src/app.js
+++ b/src/backend/auth-service/src/app.js
@@ -14,6 +14,7 @@ const cors = require("cors");
 const rateLimit = require("express-rate-limit");
 const fs = require("fs"); // DELETE LATER
 const https = require("https");
+const path = require("path");
 
 const {
     handlerErrorCsrf,
@@ -83,8 +84,8 @@ app.use(limiter);
 
 app.use(session(sessionOption)); // TOBE DETERMINED
 const fsOptions = {
-    key: fs.readFileSync("../../../../certs/localhost+1-key.pem"),
-    cert: fs.readFileSync("../../../../certs/localhost+1.pem"),
+    key: fs.readFileSync(path.join(__dirname, "../../../../certs/localhost+1-key.pem")),
+    cert: fs.readFileSync(path.join(__dirname, "../../../../certs/localhost+1.pem")),
 };
 
 // Middleware setup


### PR DESCRIPTION
## 📌 Summary
This pull request updates the way SSL certificate files are loaded in the `src/backend/auth-service/src/app.js` file. The main change is to use relative paths for the certificate and key files, which improves portability and makes the codebase easier to set up on different machines.

Security and portability improvements:

* Updated the `fsOptions` object to use relative paths (`../../../../certs/localhost+1-key.pem` and `../../../../certs/localhost+1.pem`) for loading SSL key and certificate files instead of absolute paths tied to a specific user's home directory.

This PR changes certs loading related to auth-service relevant for https.

## ☑️ Changes Included

* `erupsi-erp/src/backend/auth-service/app.js`: Change certs dir relative to repo root path.

## 📋 Checklist

<!-- You must have done this before opening a PR -->

* \[x] I have tested this code locally
* \[x] I have added/updated the unit tests to cover all my changes
* \[xI have ensured my PR matched with related docs and contracts, and updated them if necessary
* \[x] Code is linted and formatted
* \[x] No console logs or commented-out code
* \[x] My code follows the [CONTRIBUTING.md](/CONTRIBUTING.md)
